### PR TITLE
docs(auth): replace x-api-key with consumer credentials

### DIFF
--- a/api-reference/README.md
+++ b/api-reference/README.md
@@ -22,8 +22,8 @@ Upload files to lab datarooms for secure, decentralized research data storage, a
 
 **Authentication:**
 
-* **Most queries** (read operations): API Key only — public. One exception, `legalAgreementTemplate`, needs a Service Token or an authenticated session.
-* **Write mutations** (write operations): API Key plus **either** a Service Token (`X-Service-Token`) **or** a Privy user session (`Authorization` + `x-wallet-address`) — the two paths are interchangeable. Exceptions: `extendServiceToken` and `revokeServiceToken` are Service-Token-only, and `generateServiceToken` bootstraps a token from a Privy session or wallet signature.
+* **Most queries** (read operations): consumer credential only — public. One exception, `legalAgreementTemplate`, needs a Service Token or an authenticated session.
+* **Write mutations** (write operations): consumer credential plus **either** a Service Token (`X-Service-Token`) **or** a Privy user session (`Authorization` + `x-wallet-address`) — the two paths are interchangeable. Exceptions: `extendServiceToken` and `revokeServiceToken` are Service-Token-only, and `generateServiceToken` bootstraps a token from a Privy session or wallet signature.
 
 [View Labs API Documentation →](labs-api/README.md)
 
@@ -39,7 +39,7 @@ Tokenize Labs into fungible IP Tokens (IPTs) on Base.
 * Generate Lab (OCL) membership agreements
 * Manage the complete onchain tokenization workflow
 
-**Authentication:** API Key required
+**Authentication:** Consumer credential required
 
 [View Tokenization API Documentation →](tokenization-api.md)
 
@@ -72,7 +72,7 @@ Query and browse IP-NFTs, IP Tokens (IPTs), and market data across the Molecule 
 * Access trading data and market metrics
 * Build marketplace UIs and token screeners
 
-**Authentication:** API Key required
+**Authentication:** Consumer credential required
 
 [View IPNFT API Documentation (Deprecated) →](ipnft-api.md)
 
@@ -80,7 +80,7 @@ Query and browse IP-NFTs, IP Tokens (IPTs), and market data across the Molecule 
 
 ## Authentication
 
-All Molecule APIs require an API key; the Labs API additionally uses a Service Token for write operations. Obtaining credentials, the per-API header requirements, and the full Labs API authentication model (public queries vs. protected mutations) are documented on the dedicated [Authentication](authentication.md) page.
+All Molecule APIs require a consumer credential; the Labs API additionally uses a Service Token for write operations. Obtaining credentials, the per-API header requirements, and the full Labs API authentication model (public queries vs. protected mutations) are documented on the dedicated [Authentication](authentication.md) page.
 
 ***
 
@@ -99,7 +99,7 @@ Staging:    https://staging.graphql.api.molecule.xyz/graphql
 
 ### 1. Get API Access
 
-Contact the Molecule team via [Discord](https://t.co/L0VEiy4Bjk) to obtain your API key.
+Contact the Molecule team via [Discord](https://t.co/L0VEiy4Bjk) to obtain your consumer credential.
 
 ### 2. Choose Your API
 
@@ -113,12 +113,12 @@ Contact the Molecule team via [Discord](https://t.co/L0VEiy4Bjk) to obtain your 
 
 ### 3. Make Your First Request
 
-**Example (Labs API — public `labs` query, API key only):**
+**Example (Labs API — public `labs` query, consumer credential only):**
 
 ```bash
 curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Content-Type: application/json' \
-  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Authorization: Bearer YOUR_CONSUMER_CREDENTIAL' \
   -d '{
     "query": "query { labs(perPage: 5) { nodes { oclId name shortname } totalCount } }"
   }'

--- a/api-reference/authentication.md
+++ b/api-reference/authentication.md
@@ -4,23 +4,25 @@ All Molecule APIs require authentication. This page covers how to obtain credent
 
 ## Obtaining API Access
 
-All Molecule APIs require authentication with an API key. To request access:
+All Molecule APIs require authentication with a consumer credential. To request access:
 
 1. Join our [Discord community](https://t.co/L0VEiy4Bjk)
 2. Contact the Molecule team with your use case
 3. You'll receive:
-   * **API Key** - Required for all APIs
+   * **Consumer credential** (`mol_<consumerId>_<secret>`) - Required for all APIs
    * **Service Token** - Additional token for Labs API (if needed)
+
+Send the consumer credential as a bearer token: `Authorization: Bearer mol_<consumerId>_<secret>`. Treat the entire string as a secret — it is not split into a public/private part.
 
 ## Authentication Headers
 
 | API                                       | Required Headers                                                                                                  | Example                                                                                                                       |
 | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| **Labs API (queries)**                    | `x-api-key`                                                                                                       | `x-api-key: YOUR_API_KEY`                                                                                                     |
-| **Labs API (mutations, service token)**   | <p><code>x-api-key</code><br><code>X-Service-Token</code></p>                                                     | <p><code>x-api-key: YOUR_API_KEY</code><br><code>X-Service-Token: YOUR_SERVICE_TOKEN</code></p>                               |
-| **Labs API (mutations, Privy user)**      | <p><code>x-api-key</code><br><code>Authorization</code><br><code>x-wallet-address</code></p>                      | <p><code>x-api-key: YOUR_API_KEY</code><br><code>Authorization: Bearer PRIVY_TOKEN</code><br><code>x-wallet-address: 0x…</code></p> |
-| **Tokenization API**                      | `x-api-key`                                                                                                       | `x-api-key: YOUR_API_KEY`                                                                                                     |
-| **IPNFT API (Deprecated)**                | `x-api-key`                                                                                                       | `x-api-key: YOUR_API_KEY`                                                                                                     |
+| **Labs API (queries)**                    | `Authorization`                                                                                                   | `Authorization: Bearer mol_<consumerId>_<secret>`                                                                            |
+| **Labs API (mutations, service token)**   | <p><code>Authorization</code><br><code>X-Service-Token</code></p>                                                 | <p><code>Authorization: Bearer mol_&lt;consumerId&gt;_&lt;secret&gt;</code><br><code>X-Service-Token: YOUR_SERVICE_TOKEN</code></p> |
+| **Labs API (mutations, Privy user)**      | <p><code>Authorization</code><br><code>x-wallet-address</code></p>                                                | <p><code>Authorization: Bearer PRIVY_TOKEN</code><br><code>x-wallet-address: 0x…</code></p>                                  |
+| **Tokenization API**                      | `Authorization`                                                                                                   | `Authorization: Bearer mol_<consumerId>_<secret>`                                                                            |
+| **IPNFT API (Deprecated)**                | `Authorization`                                                                                                   | `Authorization: Bearer mol_<consumerId>_<secret>`                                                                            |
 
 ***
 
@@ -28,19 +30,19 @@ All Molecule APIs require authentication with an API key. To request access:
 
 The Labs API has different authentication requirements depending on the operation type:
 
-> **Rule of thumb**: Most **queries** are public (API Key only). Write **mutations** are authenticated, and most accept **either** a Service Token **or** a Privy user session — pick whichever fits your caller. The exceptions are called out below: one query is gated, the two Service Token lifecycle mutations are service-token-only, and `generateServiceToken` bootstraps a token with a Privy session or wallet signature.
+> **Rule of thumb**: Most **queries** are public (consumer credential only). Write **mutations** are authenticated, and most accept **either** a Service Token **or** a Privy user session — pick whichever fits your caller. The exceptions are called out below: one query is gated, the two Service Token lifecycle mutations are service-token-only, and `generateServiceToken` bootstraps a token with a Privy session or wallet signature.
 
 Summary of the model:
 
-* **Most queries are public**: API Key only for read operations. Exception: `legalAgreementTemplate` requires a Service Token or an authenticated session.
-* **Write mutations are authenticated, with two interchangeable paths**: API Key plus **either** `X-Service-Token` (machine callers — services, bots, agents) **or** `Authorization` + `x-wallet-address` (Privy user session — browser and app callers). Authorization is then evaluated against the caller's identity either way.
+* **Most queries are public**: consumer credential only for read operations. Exception: `legalAgreementTemplate` requires a Service Token or an authenticated session.
+* **Write mutations are authenticated, with two interchangeable paths**: consumer credential plus **either** `X-Service-Token` (machine callers — services, bots, agents) **or** `Authorization` + `x-wallet-address` (Privy user session — browser and app callers). Authorization is then evaluated against the caller's identity either way.
 * **Exceptions**: `extendServiceToken` and `revokeServiceToken` accept **only** a Service Token. `generateServiceToken` accepts **only** a Privy session or wallet signature, since it mints the token in the first place.
 * **Service Token**: Identifies which specific lab/dataroom you have write access to.
 * File-level access control is handled via Molecule's Onchain-Verified Envelope Encryption, not query authentication — see [Data Privacy & Access](../technical-deep-dive/data/data-privacy-and-access.md).
 
 ### Public Queries (Read-Only)
 
-**These queries** are public and only require an API Key:
+**These queries** are public and only require a consumer credential:
 
 - `labs` - List all labs with pagination
 - `labWithDataRoomAndFiles` - Get lab details and files
@@ -56,28 +58,27 @@ Summary of the model:
 - `listLabMembers` - List a lab's members
 
 ```bash
-x-api-key: YOUR_API_KEY
+Authorization: Bearer YOUR_CONSUMER_CREDENTIAL
 ```
 
-**Authenticated query** — API Key **plus** a Service Token, or an authenticated user session:
+**Authenticated query** — consumer credential **plus** a Service Token, or an authenticated user session:
 
 - `legalAgreementTemplate` - Get the populated agreement to sign (the signer's authenticated session, or a service token)
 
 ### Protected Mutations (Write Operations)
 
-All write mutations require an **API Key** plus proof of caller identity. For most mutations there are **two interchangeable ways** to prove identity — the resolver accepts a Service Token if one is present, and otherwise falls back to authenticating the Privy user:
+All write mutations require a **consumer credential** plus proof of caller identity. For most mutations there are **two interchangeable ways** to prove identity — the resolver accepts a Service Token if one is present, and otherwise falls back to authenticating the Privy user:
 
 **Option 1 — Service Token** (services, bots, agents, CI/CD):
 
 ```bash
-x-api-key: YOUR_API_KEY
+Authorization: Bearer YOUR_CONSUMER_CREDENTIAL
 X-Service-Token: YOUR_SERVICE_TOKEN
 ```
 
 **Option 2 — Privy user session** (browser and app callers acting as a signed-in user):
 
 ```bash
-x-api-key: YOUR_API_KEY
 Authorization: Bearer YOUR_PRIVY_TOKEN
 x-wallet-address: YOUR_WALLET_ADDRESS
 ```
@@ -104,15 +105,15 @@ Either way, the caller still has to be authorized for the target lab — a Servi
 - `revokeServiceToken` - Revoke a service token
 
 ```bash
-x-api-key: YOUR_API_KEY
+Authorization: Bearer YOUR_CONSUMER_CREDENTIAL
 X-Service-Token: YOUR_SERVICE_TOKEN
 ```
 
-> **`generateServiceToken` is the bootstrap exception**, in the opposite direction: it mints a Service Token, so it accepts *only* an API Key plus either a Privy session or a wallet signature — not a pre-existing Service Token. See [Obtaining Tokens](labs-api/service-tokens.md#obtaining-tokens).
+> **`generateServiceToken` is the bootstrap exception**, in the opposite direction: it mints a Service Token, so it accepts *only* a consumer credential plus either a Privy session or a wallet signature — not a pre-existing Service Token. See [Obtaining Tokens](labs-api/service-tokens.md#obtaining-tokens).
 
 > **Pay-per-call alternative.** Mutations tagged 💳 above can also be called through the [x402 Gateway](x402-gateway.md), which settles a USDC payment on Base per request and mints a short-lived service token on the fly — no long-lived credentials required. Useful for autonomous AI agents and third-party tools that pay for users.
 
-### Obtaining API Key and Service Token
+### Obtaining a Consumer Credential and Service Token
 
 To obtain access credentials:
 
@@ -123,7 +124,7 @@ To obtain access credentials:
    - Which lab/dataroom you need access to
    - Desired token expiration period
 3. The team will generate and provide you with:
-   - **API Key** - Used for all Molecule APIs
+   - **Consumer credential** (`mol_<consumerId>_<secret>`) - Used for all Molecule APIs
    - **Service Token** (JWT string) - Grants access to specific lab
    - **Token ID** - For management operations
 
@@ -132,27 +133,26 @@ To obtain access credentials:
 **For all queries** (read-only operations):
 
 ```bash
-x-api-key: YOUR_API_KEY
+Authorization: Bearer YOUR_CONSUMER_CREDENTIAL
 ```
 
 **For mutations** (write operations) — as a service:
 
 ```bash
-x-api-key: YOUR_API_KEY
+Authorization: Bearer YOUR_CONSUMER_CREDENTIAL
 X-Service-Token: YOUR_SERVICE_TOKEN
 ```
 
 **For mutations** — as a signed-in user (accepted by all mutations except `extendServiceToken` and `revokeServiceToken`):
 
 ```bash
-x-api-key: YOUR_API_KEY
 Authorization: Bearer YOUR_PRIVY_TOKEN
 x-wallet-address: YOUR_WALLET_ADDRESS
 ```
 
 **Why more than one header for mutations?**
 
-- **API Key**: Authenticates you as a valid Molecule API user
+- **Consumer credential**: Authenticates you as a valid Molecule API consumer
 - **Service Token**: Identifies which specific lab/dataroom your service has write access to
 - **Privy token + wallet address**: Identifies the human caller instead, whose write access is derived from their wallet's onchain role
 
@@ -161,7 +161,7 @@ Which path to choose: use a Service Token for unattended callers (backends, bots
 **Security Warnings:**
 
 - Service tokens are shown only once during generation - store them securely immediately
-- Never commit tokens or API keys to version control
+- Never commit tokens or consumer credentials to version control
 - Never log credentials in application logs
 - Store in environment variables or secure secret management systems
 - Rotate tokens regularly (quarterly recommended)

--- a/api-reference/changelog.md
+++ b/api-reference/changelog.md
@@ -8,6 +8,21 @@ This page tracks breaking changes, deprecations, and additions across the Molecu
 
 ---
 
+## Authentication
+
+### `x-api-key` replaced by consumer credentials
+
+All Molecule APIs (Labs, Tokenization, and IPNFT (Deprecated) — they share one GraphQL endpoint) now authenticate with a consumer credential instead of an `x-api-key` header. A consumer credential has the shape `mol_<consumerId>_<secret>` and is sent as a standard bearer token.
+
+```diff
+- x-api-key: YOUR_API_KEY
++ Authorization: Bearer mol_<consumerId>_<secret>
+```
+
+**Migration:** Contact the Molecule team for a consumer credential and send it as `Authorization: Bearer mol_<consumerId>_<secret>` instead of `x-api-key`. Nothing else changes: `X-Service-Token` for machine-authorized mutations, and `Authorization: Bearer <Privy token>` + `x-wallet-address` for user-authorized mutations, work exactly as before — the Privy `Authorization` header now simply doubles as the primary credential for that path too, rather than riding alongside `x-api-key`. See [Authentication](authentication.md) for the full header reference.
+
+---
+
 ## Labs API
 
 ### GraphQL introspection disabled and query depth capped in production

--- a/api-reference/labs-api/README.md
+++ b/api-reference/labs-api/README.md
@@ -18,7 +18,7 @@ The Labs API allows developers to interact with Molecule Labs datarooms without 
 
 ## Authentication
 
-The Labs API uses API-key authentication for reads and an additional Service Token for writes. Full details — public queries vs. protected mutations, obtaining and using credentials — are on the [Authentication](../authentication.md) page.
+The Labs API uses consumer-credential authentication for reads and an additional Service Token for writes. Full details — public queries vs. protected mutations, obtaining and using credentials — are on the [Authentication](../authentication.md) page.
 
 See also the functional sections: [Lab Management](lab-management.md), [Files](files.md), [Browse & Search](browse-and-search.md), [Legal Agreements](legal-agreements.md), and [Service Tokens](service-tokens.md).
 

--- a/api-reference/labs-api/browse-and-search.md
+++ b/api-reference/labs-api/browse-and-search.md
@@ -10,7 +10,7 @@ Query operations for listing all labs and reading their activity feeds. To read 
 
 Get all labs. This is a **public endpoint** - no authentication required.
 
-> **🔓 Public Endpoint**: The `labs` query does not require authentication. You only need the `x-api-key` header - no Service Token is needed.
+> **🔓 Public Endpoint**: The `labs` query does not require authentication. You only need a consumer credential (`Authorization: Bearer`) - no Service Token is needed.
 
 **GraphQL Query:**
 
@@ -72,7 +72,7 @@ These fields are sourced from the Molecule CMS and hydrated only when requested 
 ```bash
 curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Content-Type: application/json' \
-  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Authorization: Bearer YOUR_CONSUMER_CREDENTIAL' \
   -d '{
     "query": "query ListProjects($page: Int, $perPage: Int) { labs(page: $page, perPage: $perPage) { nodes { oclId shortname name labAccountAddress trlValue } totalCount pageInfo { hasNextPage currentPage totalPages } } }",
     "variables": {
@@ -86,7 +86,7 @@ curl -X POST https://production.graphql.api.molecule.xyz/graphql \
 
 Get activity timeline for a specific project including file events and announcements. This is a **public endpoint** - no authentication required.
 
-> **🔓 Public Endpoint**: The `labActivity` query does not require authentication. You only need the `x-api-key` header - no Service Token is needed.
+> **🔓 Public Endpoint**: The `labActivity` query does not require authentication. You only need a consumer credential (`Authorization: Bearer`) - no Service Token is needed.
 
 > **Filtering**: By default, returns all activity types (file events and announcements). Use the optional `filter` parameter (`ANNOUNCEMENT` or `FILE`) to retrieve only a specific type.
 
@@ -189,7 +189,7 @@ query GetProjectActivity(
 ```bash
 curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Content-Type: application/json' \
-  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Authorization: Bearer YOUR_CONSUMER_CREDENTIAL' \
   -d '{
     "query": "query GetActivity($oclId: String!, $page: Int) { labActivity(oclId: $oclId, page: $page, perPage: 20) { pageInfo { hasNextPage currentPage totalPages } nodes { __typename ... on LabEventAnnouncement { announcement { headline attachments { did path contentType } } } } } }",
     "variables": {
@@ -210,7 +210,7 @@ curl -X POST https://production.graphql.api.molecule.xyz/graphql \
 
 Get all activity across all projects. This is a **public endpoint** - no authentication required.
 
-> **🔓 Public Endpoint**: The `activities` query does not require authentication. You only need the `x-api-key` header - no Service Token is needed.
+> **🔓 Public Endpoint**: The `activities` query does not require authentication. You only need a consumer credential (`Authorization: Bearer`) - no Service Token is needed.
 
 > **Filtering**: By default, returns all activity types (file events and announcements). Use the optional `filter` parameter (`ANNOUNCEMENT` or `FILE`) to retrieve only a specific type.
 
@@ -393,7 +393,7 @@ query SearchLabs(
 ```bash
 curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Content-Type: application/json' \
-  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Authorization: Bearer YOUR_CONSUMER_CREDENTIAL' \
   -H 'X-Service-Token: YOUR_SERVICE_TOKEN' \
   -d '{
     "query": "query SearchLabs($prompt: String!, $page: Int, $perPage: Int) { searchLabs(prompt: $prompt, page: $page, perPage: $perPage) { nodes { __typename ... on SearchLabsFileHit { entry { lab { oclId shortname } path file { contentType description tags } } } ... on SearchLabsAnnouncementHit { announcement { headline body } lab { shortname } } } totalCount pageInfo { hasNextPage currentPage totalPages } } }",
@@ -410,7 +410,7 @@ curl -X POST https://production.graphql.api.molecule.xyz/graphql \
 ```bash
 curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Content-Type: application/json' \
-  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Authorization: Bearer YOUR_CONSUMER_CREDENTIAL' \
   -H 'X-Service-Token: YOUR_SERVICE_TOKEN' \
   -d '{
     "query": "query SearchLabs($prompt: String!, $filters: SearchLabsFilters) { searchLabs(prompt: $prompt, filters: $filters) { nodes { __typename ... on SearchLabsFileHit { entry { path file { tags accessLevel } } } } totalCount } }",
@@ -442,7 +442,7 @@ const searchResults = await fetch(apiUrl, {
   method: "POST",
   headers: {
     "Content-Type": "application/json",
-    "x-api-key": process.env.API_KEY,
+    "Authorization": `Bearer ${process.env.CONSUMER_CREDENTIAL}`,
     "X-Service-Token": process.env.SERVICE_TOKEN,
   },
   body: JSON.stringify({

--- a/api-reference/labs-api/files.md
+++ b/api-reference/labs-api/files.md
@@ -50,7 +50,7 @@ mutation InitiateFileUpload(
 ```bash
 curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Content-Type: application/json' \
-  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Authorization: Bearer YOUR_CONSUMER_CREDENTIAL' \
   -H 'X-Service-Token: YOUR_SERVICE_TOKEN' \
   -d '{
     "query": "mutation InitiateFileUpload($oclId: String!, $contentType: String!, $contentLength: Int!) { initiateCreateOrUpdateFile(oclId: $oclId, contentType: $contentType, contentLength: $contentLength) { uploadToken uploadUrl uploadUrlExpiry method headers { key value } isSuccess error { message code retryable } } }",
@@ -182,7 +182,7 @@ _\*Use `path` for new files OR `ref` for versions - not both_
 ```bash
 curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Content-Type: application/json' \
-  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Authorization: Bearer YOUR_CONSUMER_CREDENTIAL' \
   -H 'X-Service-Token: YOUR_SERVICE_TOKEN' \
   -d '{
     "query": "mutation FinishFileUpload($oclId: String!, $uploadToken: String!, $path: String, $accessLevel: String!, $changeBy: String!, $description: String, $tags: [String!], $categories: [String!], $contentText: String) { finishCreateOrUpdateFile(oclId: $oclId, uploadToken: $uploadToken, path: $path, accessLevel: $accessLevel, changeBy: $changeBy, description: $description, tags: $tags, categories: $categories, contentText: $contentText) { datasetId contentHash version isSuccess message error { message code retryable } } }",
@@ -242,7 +242,7 @@ async function uploadFileToLabs(filePath, oclId, serviceToken) {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "x-api-key": process.env.API_KEY,
+        "Authorization": `Bearer ${process.env.CONSUMER_CREDENTIAL}`,
         "X-Service-Token": serviceToken,
       },
       body: JSON.stringify({
@@ -306,7 +306,7 @@ async function uploadFileToLabs(filePath, oclId, serviceToken) {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "x-api-key": process.env.API_KEY,
+        "Authorization": `Bearer ${process.env.CONSUMER_CREDENTIAL}`,
         "X-Service-Token": serviceToken,
       },
       body: JSON.stringify({
@@ -388,7 +388,7 @@ module.exports = { uploadFileToLabs };
 **Usage:**
 
 ```bash
-API_KEY="your-api-key" SERVICE_TOKEN="your-service-token" WALLET_ADDRESS="0x..." node upload.js data.pdf 0x0101000000000000000000000000000000000000000000000000000000000042
+CONSUMER_CREDENTIAL="mol_your-consumer-id_your-secret" SERVICE_TOKEN="your-service-token" WALLET_ADDRESS="0x..." node upload.js data.pdf 0x0101000000000000000000000000000000000000000000000000000000000042
 ```
 ---
 
@@ -436,7 +436,7 @@ mutation CreateAnnouncement(
 ```bash
 curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Content-Type: application/json' \
-  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Authorization: Bearer YOUR_CONSUMER_CREDENTIAL' \
   -H 'X-Service-Token: YOUR_SERVICE_TOKEN' \
   -d '{
     "query": "mutation CreateAnnouncement($oclId: String!, $headline: String!, $body: String!, $attachments: [String!]) { createAnnouncement(oclId: $oclId, headline: $headline, body: $body, attachments: $attachments) { isSuccess message error { message } } }",
@@ -506,7 +506,7 @@ mutation UpdateFileMetadata(
 ```bash
 curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Content-Type: application/json' \
-  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Authorization: Bearer YOUR_CONSUMER_CREDENTIAL' \
   -H 'X-Service-Token: YOUR_SERVICE_TOKEN' \
   -d '{
     "query": "mutation UpdateFileMetadata($oclId: String!, $ref: String!, $accessLevel: String!, $description: String, $tags: [String!], $categories: [String!], $contentText: String) { updateFileMetadata(oclId: $oclId, ref: $ref, accessLevel: $accessLevel, description: $description, tags: $tags, categories: $categories, contentText: $contentText) { ref isSuccess message error { message } } }",
@@ -560,7 +560,7 @@ mutation DeleteFile($oclId: String!, $path: String!, $changeBy: String!) {
 ```bash
 curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Content-Type: application/json' \
-  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Authorization: Bearer YOUR_CONSUMER_CREDENTIAL' \
   -H 'X-Service-Token: YOUR_SERVICE_TOKEN' \
   -d '{
     "query": "mutation DeleteFile($oclId: String!, $path: String!, $changeBy: String!) { deleteDataRoomFile(oclId: $oclId, path: $path, changeBy: $changeBy) { oclId filePath isSuccess error { message } } }",
@@ -603,7 +603,7 @@ query GetFile($oclId: String!, $path: String!) {
 ```bash
 curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Content-Type: application/json' \
-  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Authorization: Bearer YOUR_CONSUMER_CREDENTIAL' \
   -H 'X-Service-Token: YOUR_SERVICE_TOKEN' \
   -d '{
     "query": "query GetFile($oclId: String!, $path: String!) { dataRoomFile(oclId: $oclId, path: $path) { did path contentType accessLevel downloadUrl } }",

--- a/api-reference/labs-api/lab-management.md
+++ b/api-reference/labs-api/lab-management.md
@@ -58,14 +58,13 @@ The mutation takes a single `CreateLabInput` object:
 **Option 1: Service Token (Recommended for Automation)**
 
 ```bash
-x-api-key: YOUR_API_KEY
+Authorization: Bearer YOUR_CONSUMER_CREDENTIAL
 X-Service-Token: YOUR_SERVICE_TOKEN
 ```
 
 **Option 2: Privy Token (User-Initiated)**
 
 ```bash
-x-api-key: YOUR_API_KEY
 Authorization: Bearer YOUR_PRIVY_TOKEN
 x-wallet-address: YOUR_WALLET_ADDRESS
 ```
@@ -75,7 +74,7 @@ x-wallet-address: YOUR_WALLET_ADDRESS
 ```bash
 curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Content-Type: application/json' \
-  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Authorization: Bearer YOUR_CONSUMER_CREDENTIAL' \
   -H 'X-Service-Token: YOUR_SERVICE_TOKEN' \
   -d '{
     "query": "mutation CreateLab($oclId: String!) { createLab(input: { oclId: $oclId }) { isSuccess message error { message code retryable } lab { oclId shortname labAccountAddress labNftTokenId } } }",
@@ -184,7 +183,7 @@ To obtain a service token for automated lab creation:
    * Use case description
    * Intended automation workflow
 4. You'll receive:
-   * API Key (for all APIs)
+   * Consumer credential (for all APIs)
    * Service Token (JWT for lab creation)
    * Token expiration date
 
@@ -194,7 +193,7 @@ To obtain a service token for automated lab creation:
 
 Retrieve complete details for a specific lab including all files. This is a **public endpoint** - no authentication required. Look up a lab by its `oclId` or, alternatively, by its human-readable `shortname` — provide exactly one.
 
-> **🔓 Public Endpoint**: The `labWithDataRoomAndFiles` query does not require authentication. You only need the `x-api-key` header - no Service Token is needed. File-level access control is handled via encryption rather than query-level authentication.
+> **🔓 Public Endpoint**: The `labWithDataRoomAndFiles` query does not require authentication. You only need a consumer credential (`Authorization: Bearer`) - no Service Token is needed. File-level access control is handled via encryption rather than query-level authentication.
 
 **GraphQL Query:**
 
@@ -230,7 +229,7 @@ query GetProject($oclId: String!) {
 ```bash
 curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Content-Type: application/json' \
-  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Authorization: Bearer YOUR_CONSUMER_CREDENTIAL' \
   -d '{
     "query": "query GetProject($oclId: String!) { labWithDataRoomAndFiles(oclId: $oclId) { oclId shortname dataRoom { id files { path contentType accessLevel tags } } } }",
     "variables": {
@@ -317,7 +316,7 @@ mutation GenerateLabImageUploadUrl($oclId: String!, $contentType: String!) {
 
 Return the active members of a lab (owner, contributors, viewers), sourced from the indexed `ocl_user` table. Expired grants are excluded.
 
-> **Public query** — only an API Key is required. The same data is also exposed on the public `Lab` / `LabRef.members` field.
+> **Public query** — only a consumer credential is required. The same data is also exposed on the public `Lab` / `LabRef.members` field.
 
 ```graphql
 query ListLabMembers($oclId: String!) {

--- a/api-reference/tokenization-api.md
+++ b/api-reference/tokenization-api.md
@@ -15,26 +15,26 @@ The Tokenization API enables developers to generate Lab (OCL) membership agreeme
 
 ## Authentication
 
-All Tokenization API mutations require an API key.
+All Tokenization API mutations require a consumer credential.
 
-### Obtaining an API Key
+### Obtaining a Consumer Credential
 
-To request an API key and access to the full technical integration guide:
+To request a consumer credential and access to the full technical integration guide:
 
 1. Join our [Discord community](https://t.co/L0VEiy4Bjk)
 2. Contact the Molecule team with:
    * Your use case and project details
    * Expected tokenization volume
 3. You'll receive:
-   * **API Key** for authentication
+   * **Consumer credential** (`mol_<consumerId>_<secret>`) for authentication
    * **Technical Integration Guide** with complete code examples and ABI files
 
-### Using Your API Key
+### Using Your Consumer Credential
 
-Include the API key in all requests using the `x-api-key` header:
+Include the consumer credential in all requests using the `Authorization` header:
 
 ```bash
-x-api-key: YOUR_API_KEY
+Authorization: Bearer YOUR_CONSUMER_CREDENTIAL
 ```
 
 ***
@@ -92,7 +92,7 @@ Generate the membership agreement for an onchain lab (OCL) — the terms documen
 ```bash
 curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Content-Type: application/json' \
-  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Authorization: Bearer YOUR_CONSUMER_CREDENTIAL' \
   -d '{
     "query": "mutation GenerateOclMembershipAgreement($agreementData: AWSJSON!) { generateOclMembershipAgreement(agreementData: $agreementData) { agreementKey agreementUrl agreementContentHash agreementType generatedAt isSuccess error { message } } }",
     "variables": {
@@ -170,7 +170,7 @@ The terms message is reconstructed onchain by `OclTermsPermissioner.specificTerm
 
 ### For Lab Tokenization
 
-* **API Key**: Obtained from Molecule team
+* **Consumer credential**: Obtained from Molecule team
 * **Lab Control**: The caller must be the Lab's controller (the current LabNFT owner)
 * **Base ETH Balance**: Sufficient for gas fees on Base
 * **Token Details**: Symbol and initial supply amount (the token name is derived automatically)
@@ -196,7 +196,7 @@ All mutations follow a consistent error response format:
 
 | Error Code                | Description                                  | Solution                               |
 | ------------------------- | -------------------------------------------- | -------------------------------------- |
-| 401 Unauthorized          | Missing or invalid API key                   | Check `x-api-key` header               |
+| 401 Unauthorized          | Missing or invalid consumer credential       | Check `Authorization: Bearer` header   |
 | 400 Bad Request           | Invalid parameters or malformed JSON         | Verify input data format               |
 | `INVALID_INPUT`           | Required fields missing or malformed         | Verify the input object shape          |
 
@@ -270,7 +270,7 @@ console.log('Lab tokenized!', txHash);
 
 ### Security
 
-* Never expose API keys in client-side code
+* Never expose consumer credentials in client-side code
 * Use environment variables for credentials
 * Implement proper wallet key management
 * Verify all signatures and authorizations

--- a/technical-deep-dive/data/data-api-and-integration.md
+++ b/technical-deep-dive/data/data-api-and-integration.md
@@ -46,7 +46,7 @@ The API serves two broad categories of data. Market and token data — represent
 
 Research and Lab data — representing the remaining 15% — includes data room file listings, file versions, announcements, project activity feeds, and semantic search results. This data is served through the Labs API, which reads from Kamu for file metadata and provenance, and generates presigned S3 URLs through Filebase for file uploads and downloads.
 
-The API uses a two-tier authentication model. Read operations (queries) require an API key, issued by the Molecule team upon request. Write operations (mutations) — file uploads, metadata updates, announcements — require both an API key and a service token, which is scoped to a specific wallet address and Lab. Service tokens have configurable expiration and can be extended or revoked through the API. For detailed authentication setup, credential management, and rate limits, see the Labs API reference page.
+The API uses a two-tier authentication model. Read operations (queries) require a consumer credential, issued by the Molecule team upon request. Write operations (mutations) — file uploads, metadata updates, announcements — require both a consumer credential and a service token, which is scoped to a specific wallet address and Lab. Service tokens have configurable expiration and can be extended or revoked through the API. For detailed authentication setup, credential management, and rate limits, see the Labs API reference page.
 
 ### How Consumers Access Data
 
@@ -75,7 +75,7 @@ Search results can be filtered by tags, categories, access levels, and content k
 
 ### Access Levels and Gating
 
-The API enforces access levels at the file level, consistent with the access control model described in the Data Privacy & Access page. Public files are accessible to any API consumer without authentication. Admin-restricted files require a valid API key and service token tied to an authorised wallet. Token-holder-gated files are accepted by the API but require onchain verification for decryption — the API serves the encrypted blob and encryption metadata, and only wallets that satisfy the stored access conditions (re-verified against live chain state) can obtain the unwrapped data encryption key (through `decryptDataKey` for current-flow files).
+The API enforces access levels at the file level, consistent with the access control model described in the Data Privacy & Access page. Public files are accessible to any API consumer without authentication. Admin-restricted files require a valid consumer credential and service token tied to an authorised wallet. Token-holder-gated files are accepted by the API but require onchain verification for decryption — the API serves the encrypted blob and encryption metadata, and only wallets that satisfy the stored access conditions (re-verified against live chain state) can obtain the unwrapped data encryption key (through `decryptDataKey` for current-flow files).
 
 This means the API can serve file metadata (path, version, content type, access level) for any file regardless of access level, but the actual file content for encrypted files is only accessible to authorised parties who satisfy the stored access conditions and then decrypt client-side.
 

--- a/user-guides/developers-ai-agents.md
+++ b/user-guides/developers-ai-agents.md
@@ -18,7 +18,7 @@ The reference pages (Contracts, Labs API, MCP Tools) contain the full API specif
 
 Molecule exposes four primary integration layers, each serving different developer needs.
 
-The Labs API is a GraphQL endpoint for reading and writing to Lab data rooms — the offchain encrypted storage where research files, announcements, and metadata live. This is the primary interface for applications that need to manage scientific data: uploading files, querying project activity, searching across Labs, and managing announcements. Authentication uses API keys for reads and service tokens for writes. The full specification, including every query and mutation, is documented in the Labs API reference.
+The Labs API is a GraphQL endpoint for reading and writing to Lab data rooms — the offchain encrypted storage where research files, announcements, and metadata live. This is the primary interface for applications that need to manage scientific data: uploading files, querying project activity, searching across Labs, and managing announcements. Authentication uses consumer credentials for reads and service tokens for writes. The full specification, including every query and mutation, is documented in the Labs API reference.
 
 The Smart Contracts are the onchain layer. The V2 contracts (IPNFT, CrowdSale, SchmackoSwap) on Ethereum mainnet underpin the existing IP-NFT assets, token sales, and trading. The V3 contracts (OnChainLab, OnChainLabFactory, ERC7484Registry, OclTokenizer, and associated modules) are deployed on Base mainnet and Base Sepolia and introduce the modular account architecture plus Lab tokenization. Contract addresses, ABIs, and upgrade patterns are documented in the Contracts reference. The Architecture page provides the full implementation-level breakdown of how these contracts compose.
 
@@ -52,9 +52,9 @@ The Base Sepolia deployment includes all the infrastructure you need for testing
 
 AI agents that operate on Lab data — reading files, running analyses, writing findings back — interact through the Labs API. The protocol treats agent outputs the same as any other data: versioned records with content identifiers, permanent onchain references, and configurable access control.
 
-The simplest agent integration is read-only: query a Lab's data room for files, download them, perform analysis, and present results. This requires only an API key. Querying `labWithDataRoomAndFiles` gives you the complete file list with download URLs, content types, and encryption metadata. For encrypted files, the agent calls `decryptDataKey` with its service token; the backend evaluates the file's onchain access conditions and, if satisfied, returns the plaintext DEK. Access commonly resolves through a [Viewer or Contributor role grant](../technical-deep-dive/roles-and-permissions.md) on the Lab — granted by the Lab owner with `isAgent = true` and a bounded `expiry` matching the agent's session-key lifetime.
+The simplest agent integration is read-only: query a Lab's data room for files, download them, perform analysis, and present results. This requires only a consumer credential. Querying `labWithDataRoomAndFiles` gives you the complete file list with download URLs, content types, and encryption metadata. For encrypted files, the agent calls `decryptDataKey` with its service token; the backend evaluates the file's onchain access conditions and, if satisfied, returns the plaintext DEK. Access commonly resolves through a [Viewer or Contributor role grant](../technical-deep-dive/roles-and-permissions.md) on the Lab — granted by the Lab owner with `isAgent = true` and a bounded `expiry` matching the agent's session-key lifetime.
 
-A write-enabled agent goes further: it reads data, performs analysis, and writes results back as new files in the Lab's data room. This requires both an API key and a service token. Two paths to a service token:
+A write-enabled agent goes further: it reads data, performs analysis, and writes results back as new files in the Lab's data room. This requires both a consumer credential and a service token. Two paths to a service token:
 
 * **Long-lived service token** — mint one via the `generateServiceToken` mutation (wallet signature or Privy session), or contact the Molecule team. The token is a JWT tied to your wallet; write authorization is resolved from that wallet's onchain role on the target Lab.
 * **Pay-per-call via the** [**x402 Gateway**](../api-reference/x402-gateway.md) — for agents that serve external users, charge per request, or don't have pre-provisioned credentials. The gateway settles a USDC payment on Base per call and mints a short-lived (default 5-minute) service token scoped to one mutation. Available for `initiateCreateOrUpdateFile`, `finishCreateOrUpdateFile`, `createAnnouncement`, `createLab`, `generateDataEncryptionKey`, and `decryptDataKey`.
@@ -99,4 +99,4 @@ If you're building an AI research agent, start with BioAgents. Fork the reposito
 
 If you just want to give an AI assistant Molecule context, add the MCP server URL to your client's config and you're done in sixty seconds.
 
-For API keys, service tokens, attestation requests, or any integration support, reach out on the Molecule Discord.
+For consumer credentials, service tokens, attestation requests, or any integration support, reach out on the Molecule Discord.

--- a/user-guides/scientists-researchers.md
+++ b/user-guides/scientists-researchers.md
@@ -16,7 +16,7 @@ Setting one up takes an email address, with no wallet or prior crypto experience
 
 Everything inside a Lab is available through Molecule's interface, where a researcher signs in by email, uploads files, invites collaborators, and manages funding without touching any code.&#x20;
 
-For a workflow that already runs on scripts or AI agents, the same Lab is reachable through an API key, and files, updates, and project activity move through the same underlying data whichever pathway is used. An agent-native researcher can pull work into their own tools and push new findings back, keeping the Lab's public record current throughout.&#x20;
+For a workflow that already runs on scripts or AI agents, the same Lab is reachable through a consumer credential, and files, updates, and project activity move through the same underlying data whichever pathway is used. An agent-native researcher can pull work into their own tools and push new findings back, keeping the Lab's public record current throughout.&#x20;
 
 Both pathways carry the same security and access rules, so working through the API never changes who can see what.
 


### PR DESCRIPTION
Molecule APIs now authenticate machine callers via Authorization: Bearer mol_<consumerId>_<secret> instead of the x-api-key header, matching the appsync-authorizer-lambda consumer-credential rollout in desci-infra. Updates authentication.md, the Labs/Tokenization API reference pages, and narrative mentions across user-guides and technical-deep-dive; adds a changelog entry with a migration example. Service Token and Privy bearer/x-wallet-address flows are unchanged. The deprecated/orphan IPNFT API pages are left untouched per the docs-sync guardrails.