### PR TITLE
docs(labs-api): drop the removed isSuccess envelope from the Labs API reference (IP-2922)

### DIFF
--- a/api-reference/labs-api/README.md
+++ b/api-reference/labs-api/README.md
@@ -26,52 +26,117 @@ See also the functional sections: [Lab Management](lab-management.md), [Files](f
 
 ## Error Handling
 
-All API responses follow a consistent error format:
+The Labs API is a GraphQL API: once a request is accepted, the response is HTTP `200` whether or not the operation succeeded — success and failure are signalled inside the JSON body, not by the status code. Errors surface through one of two channels, depending on the operation class:
 
-### Error Response Structure
+- **Queries throw.** A failed query adds an entry to the top-level GraphQL `errors[]` array and returns `null` for that field. Most Labs query result types are non-null, so the null propagates and `data` itself comes back `null` (as in the example below); only `labWithDataRoomAndFiles` and `dataRoomFile` are nullable and null just their own field. `errorType` carries the error code (the only value to branch on) and `errorInfo` carries `{ requestId, retryable, details }`.
+- **Mutations return errors in-band.** Every mutation result type carries an `error: ApiError` field. **Success ⇔ `error == null`.** Where the result type also has a top-level `message`, it mirrors `error.message` on failure and is never empty. A top-level `errors[]` entry on a mutation means a transport or infrastructure failure, or that the request document itself failed validation.
+
+Branch on the code — never on `message` text, which may change without notice. Include `requestId` whenever you report a problem.
+
+### Failed Query
+
+```json
+{
+  "data": null,
+  "errors": [
+    {
+      "path": ["listLabMembers"],
+      "message": "Project not found: 0x0101000000000000000000000000000000000000000000000000000000000042",
+      "errorType": "NOT_FOUND",
+      "errorInfo": {
+        "requestId": "8f1e4c9a-2b7d-4e10-9c3a-5d6f7a8b9c0d",
+        "retryable": false,
+        "details": { "reason": "PROJECT_NOT_FOUND" }
+      }
+    }
+  ]
+}
+```
+
+### Failed Mutation
+
+Select `error { code message requestId retryable details }` on every mutation:
+
+```graphql
+type ApiError {
+  code: String!       # error code from the catalogue below — the only field to branch on
+  message: String!    # human-readable, never empty; not part of the contract
+  requestId: String!  # correlation id — include it in bug reports
+  retryable: Boolean! # whether retrying the same request unchanged can plausibly succeed
+  details: AWSJSON    # optional structured context (JSON-encoded string)
+}
+```
+
+```graphql
+mutation InitiateFileUpload($oclId: String!, $contentType: String!, $contentLength: Int!) {
+  initiateCreateOrUpdateFile(oclId: $oclId, contentType: $contentType, contentLength: $contentLength) {
+    uploadUrl
+    error { code message requestId retryable details }
+  }
+}
+```
 
 ```json
 {
   "data": {
     "initiateCreateOrUpdateFile": {
-      "isSuccess": false,
+      "uploadUrl": null,
       "error": {
-        "message": "Error description",
-        "code": "ERROR_CODE",
-        "retryable": true
+        "code": "UNAUTHORIZED",
+        "message": "You are not allowed to perform this operation.",
+        "requestId": "8f1e4c9a-2b7d-4e10-9c3a-5d6f7a8b9c0d",
+        "retryable": false,
+        "details": "{\"reason\":\"UNAUTHORIZED\"}"
       }
     }
   }
 }
 ```
 
-### Common Error Codes
+In-band `details` is a JSON-encoded string — parse it with `JSON.parse(error.details ?? "{}")` (on thrown queries, `errorInfo.details` is already an object). Documented keys are `field` (the offending input field), `reason` (a more specific cause under the code, e.g. `PROJECT_NOT_FOUND` under `NOT_FOUND`), `hint` and `docs`; ignore unknown keys. `reason` values are diagnostic refinement and may be extended at any time — branch on `code` first.
 
-| Status Code | Error                 | Description                                                   |
-| ----------- | --------------------- | ------------------------------------------------------------- |
-| 401         | Unauthorized          | Missing or invalid service token                              |
-| 403         | Forbidden             | Service token does not have access to the specified lab       |
-| 400         | Bad Request           | Invalid parameters (e.g., missing oclId, invalid contentType) |
-| 404         | Not Found             | Lab or dataroom not found                                     |
-| 413         | Payload Too Large     | File exceeds size limits                                      |
-| 500         | Internal Server Error | Server error - check if retryable and try again               |
+```javascript
+const result = (await response.json()).data.initiateCreateOrUpdateFile; // `response` from your fetch()
+
+if (result.error) {
+  const { code, message, requestId, retryable, details } = result.error;
+  const { reason } = JSON.parse(details ?? "{}");
+  if (retryable) return retryWithBackoff(); // RATE_LIMITED, TIMEOUT, UPSTREAM_UNAVAILABLE, INTERNAL_ERROR
+  throw new Error(`${code}${reason ? `/${reason}` : ""}: ${message} (requestId ${requestId})`);
+}
+```
+
+### Error Codes
+
+| Code                        | `retryable` | Meaning                                                                                              |
+| --------------------------- | ----------- | ---------------------------------------------------------------------------------------------------- |
+| `UNAUTHENTICATED`           | false       | Missing, invalid or expired credentials                                                              |
+| `UNAUTHORIZED`              | false       | Authenticated, but not allowed (role/membership)                                                     |
+| `NOT_FOUND`                 | false       | Referenced resource doesn't exist                                                                    |
+| `VALIDATION_FAILED`         | false       | Input failed validation (unknown filter/sort fields, out-of-range pagination, malformed ids); `details.field` names the offender |
+| `CONFLICT`                  | false       | Valid request conflicts with current state (e.g. `details.reason` `SHORTNAME_TAKEN`, `ALREADY_SIGNED`) |
+| `FAILED_PRECONDITION`       | false       | Resource state makes the operation impossible until the state changes (e.g. `TEMPLATE_EXPIRED`)      |
+| `COMPLEXITY_LIMIT_EXCEEDED` | false       | Query shape or result size over limits                                                               |
+| `RATE_LIMITED`              | **true**    | Throttled — retry with backoff                                                                       |
+| `TIMEOUT`                   | **true**    | Execution exceeded the request budget                                                                |
+| `UPSTREAM_UNAVAILABLE`      | **true**    | A dependency failed (`details.reason` `KAMU`, `CMS`, `IPFS`)                                         |
+| `INTERNAL_ERROR`            | **true**    | Unexpected failure — details are only in our logs, joined by `requestId`                             |
+
+When `retryable` is `true`, retry with exponential backoff; when `false`, the request (or the resource state) must change before retrying. Any code not listed here: preserve it for diagnostics, treat it as non-retryable and surface it to a human — new codes are announced in the [API Changelog](../changelog.md). `PAYMENT_REQUIRED` is reserved for the [x402 Gateway](../x402-gateway.md) and is not emitted by the GraphQL API.
 
 ### Troubleshooting
 
-**"Missing service token" error:**
+**`UNAUTHENTICATED`** — missing, invalid or expired service token:
 
-- Ensure `X-Service-Token` header is included in requests
-- Verify token is not empty or malformed
+- Ensure the `X-Service-Token` header is included in mutation requests
+- Verify the token is not empty or malformed
+- If the token has expired, request a new token from the Molecule team, or use the `extendServiceToken` mutation to extend expiration
 
-**"Service does not have access to lab" error:**
+A missing or malformed consumer credential is rejected before the GraphQL layer runs (an HTTP `401` from the API, not one of the error codes below) — check the `Authorization` header first, see [Authentication](../authentication.md).
 
-- Verify your wallet address (linked to service token) has admin access to the lab/dataroom
-- Check that the oclId format is correct: a 32-byte hex string with `0x` prefix
+**`UNAUTHORIZED`** — the wallet behind the service token lacks the required role on the lab:
 
-**"Token expired" error:**
-
-- Request a new token from the Molecule team, or
-- Use `extendServiceToken` mutation to extend expiration
+- Verify your wallet address (linked to the service token) has admin access to the lab/dataroom (or the role the operation requires)
 
 **Upload to presigned URL fails:**
 
@@ -79,16 +144,19 @@ All API responses follow a consistent error format:
 - Verify headers match those returned in Step 1
 - Check that presigned URL hasn't expired (expires after \~15 minutes)
 
-**"File not found" error (updateFileMetadata, deleteDataRoomFile):**
+**`NOT_FOUND`** — lab, dataroom or file not found:
 
-- Verify the file `ref` (DID) or `path` is correct
-- Check that the file exists in the specified dataroom
-- Ensure you have access to the dataroom
+- Verify the `oclId` refers to a registered lab
+- For `updateFileMetadata` / `deleteDataRoomFile`: verify the file `ref` (DID) or `path` is correct and the file exists in the specified dataroom
 
-**"Invalid search filters" error (searchLabs):**
+**`VALIDATION_FAILED`** — invalid parameters; `details.field` names the offending input:
 
-- Verify filter values match expected types (arrays of strings)
-- Ensure oclId format is correct if using byOclIds filter
+- Check that the `oclId` format is correct: a 32-byte hex string with `0x` prefix
+- For `searchLabs`: verify filter values match expected types (arrays of strings)
+
+**Retryable errors (`RATE_LIMITED`, `TIMEOUT`, `UPSTREAM_UNAVAILABLE`, `INTERNAL_ERROR`):**
+
+- Retry with exponential backoff; if the failure persists, report it with the `requestId`
 
 ---
 

--- a/api-reference/labs-api/browse-and-search.md
+++ b/api-reference/labs-api/browse-and-search.md
@@ -219,7 +219,6 @@ Get all activity across all projects. This is a **public endpoint** - no authent
 ```graphql
 query GetActivities($page: Int, $perPage: Int, $filter: LabActivityFilter) {
   activities(page: $page, perPage: $perPage, filter: $filter) {
-    isSuccess
     activities {
       __typename
       ... on LabEventFileAdded {
@@ -292,10 +291,11 @@ query GetActivities($page: Int, $perPage: Int, $filter: LabActivityFilter) {
         }
       }
     }
-    error
   }
 }
 ```
+
+> **Errors**: a failed `activities` query returns `data: null` with a top-level GraphQL `errors[]` entry whose `errorType` is the error code — see [Error Handling](README.md#error-handling).
 
 ---
 

--- a/api-reference/labs-api/files.md
+++ b/api-reference/labs-api/files.md
@@ -2,6 +2,8 @@
 
 Working with files in a Lab dataroom: the three-step upload flow (initiate → upload → finish), plus announcements, metadata updates, deletion, storage limits, and client-side encryption. Creating the Lab itself is covered in [Lab Management](lab-management.md).
 
+> **Note**: Every mutation on this page returns its failure in-band: the result carries `error: ApiError`, and success means `error` is `null`. Branch on `error.code` — never on `message` text — and quote `requestId` when reporting a problem. See [Error Handling](README.md#error-handling) for the `ApiError` shape, how to read `details`, and the list of error codes.
+
 ## Step 1: Initiate File Upload
 
 Initiates the upload process and returns a presigned URL for direct file upload.
@@ -27,11 +29,12 @@ mutation InitiateFileUpload(
       key
       value
     }
-    isSuccess
     error {
-      message
       code
+      message
+      requestId
       retryable
+      details
     }
   }
 }
@@ -53,7 +56,7 @@ curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Authorization: YOUR_CONSUMER_CREDENTIAL' \
   -H 'X-Service-Token: YOUR_SERVICE_TOKEN' \
   -d '{
-    "query": "mutation InitiateFileUpload($oclId: String!, $contentType: String!, $contentLength: Int!) { initiateCreateOrUpdateFile(oclId: $oclId, contentType: $contentType, contentLength: $contentLength) { uploadToken uploadUrl uploadUrlExpiry method headers { key value } isSuccess error { message code retryable } } }",
+    "query": "mutation InitiateFileUpload($oclId: String!, $contentType: String!, $contentLength: Int!) { initiateCreateOrUpdateFile(oclId: $oclId, contentType: $contentType, contentLength: $contentLength) { uploadToken uploadUrl uploadUrlExpiry method headers { key value } error { code message requestId retryable details } } }",
     "variables": {
       "oclId": "0x0101000000000000000000000000000000000000000000000000000000000042",
       "contentType": "application/pdf",
@@ -78,12 +81,13 @@ curl -X POST https://production.graphql.api.molecule.xyz/graphql \
           "value": "application/pdf"
         }
       ],
-      "isSuccess": true,
       "error": null
     }
   }
 }
 ```
+
+On failure `error` is set and the upload fields (`uploadToken`, `uploadUrl`, `uploadUrlExpiry`, `method`, `headers`) are `null`; do not proceed to Step 2 unless `error` is `null`.
 
 ## Step 2: Upload File to Storage
 
@@ -150,12 +154,13 @@ mutation FinishFileUpload(
     datasetId
     contentHash
     version
-    isSuccess
     message
     error {
-      message
       code
+      message
+      requestId
       retryable
+      details
     }
   }
 }
@@ -185,7 +190,7 @@ curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Authorization: YOUR_CONSUMER_CREDENTIAL' \
   -H 'X-Service-Token: YOUR_SERVICE_TOKEN' \
   -d '{
-    "query": "mutation FinishFileUpload($oclId: String!, $uploadToken: String!, $path: String, $accessLevel: String!, $changeBy: String!, $description: String, $tags: [String!], $categories: [String!], $contentText: String) { finishCreateOrUpdateFile(oclId: $oclId, uploadToken: $uploadToken, path: $path, accessLevel: $accessLevel, changeBy: $changeBy, description: $description, tags: $tags, categories: $categories, contentText: $contentText) { datasetId contentHash version isSuccess message error { message code retryable } } }",
+    "query": "mutation FinishFileUpload($oclId: String!, $uploadToken: String!, $path: String, $accessLevel: String!, $changeBy: String!, $description: String, $tags: [String!], $categories: [String!], $contentText: String) { finishCreateOrUpdateFile(oclId: $oclId, uploadToken: $uploadToken, path: $path, accessLevel: $accessLevel, changeBy: $changeBy, description: $description, tags: $tags, categories: $categories, contentText: $contentText) { datasetId contentHash version message error { code message requestId retryable details } } }",
     "variables": {
       "oclId": "0x0101000000000000000000000000000000000000000000000000000000000042",
       "uploadToken": "TOKEN_FROM_STEP_1",
@@ -209,9 +214,30 @@ curl -X POST https://production.graphql.api.molecule.xyz/graphql \
       "datasetId": "did:kamu:...",
       "contentHash": "sha256:abc123...",
       "version": 1,
-      "isSuccess": true,
       "message": "File uploaded successfully",
       "error": null
+    }
+  }
+}
+```
+
+**Failure Response** (HTTP 200, no top-level `errors[]` — `message` mirrors `error.message`):
+
+```json
+{
+  "data": {
+    "finishCreateOrUpdateFile": {
+      "datasetId": null,
+      "contentHash": null,
+      "version": null,
+      "message": "You are not allowed to perform this operation.",
+      "error": {
+        "code": "UNAUTHORIZED",
+        "message": "You are not allowed to perform this operation.",
+        "requestId": "8f1e4c9a-2b7d-4e10-9c3a-5d6f7a8b9c0d",
+        "retryable": false,
+        "details": "{\"reason\":\"UNAUTHORIZED\"}"
+      }
     }
   }
 }
@@ -257,8 +283,7 @@ async function uploadFileToLabs(filePath, oclId, serviceToken) {
               uploadUrl
               method
               headers { key value }
-              isSuccess
-              error { message }
+              error { code message requestId retryable details }
             }
           }
         `,
@@ -271,10 +296,19 @@ async function uploadFileToLabs(filePath, oclId, serviceToken) {
     });
 
     const initiateResult = await initiateResponse.json();
-    if (!initiateResult.data?.initiateCreateOrUpdateFile?.isSuccess) {
+    if (initiateResult.errors?.length) {
+      // Top-level errors on a mutation mean a transport or request-validation failure
+      const e = initiateResult.errors[0];
       throw new Error(
-        initiateResult.data?.initiateCreateOrUpdateFile?.error?.message ||
-          "Failed to initiate upload",
+        `${e.errorType ?? "Request failed"}: ${e.message}${
+          e.errorInfo?.requestId ? ` (requestId ${e.errorInfo.requestId})` : ""
+        }`,
+      );
+    }
+    const initiateError = initiateResult.data.initiateCreateOrUpdateFile.error;
+    if (initiateError) {
+      throw new Error(
+        `${initiateError.code}: ${initiateError.message} (requestId ${initiateError.requestId})`,
       );
     }
 
@@ -326,9 +360,8 @@ async function uploadFileToLabs(filePath, oclId, serviceToken) {
               changeBy: $changeBy
             ) {
               datasetId
-              isSuccess
               message
-              error { message }
+              error { code message requestId retryable details }
             }
           }
         `,
@@ -343,10 +376,18 @@ async function uploadFileToLabs(filePath, oclId, serviceToken) {
     });
 
     const finishResult = await finishResponse.json();
-    if (!finishResult.data?.finishCreateOrUpdateFile?.isSuccess) {
+    if (finishResult.errors?.length) {
+      const e = finishResult.errors[0];
       throw new Error(
-        finishResult.data?.finishCreateOrUpdateFile?.error?.message ||
-          "Failed to finish upload",
+        `${e.errorType ?? "Request failed"}: ${e.message}${
+          e.errorInfo?.requestId ? ` (requestId ${e.errorInfo.requestId})` : ""
+        }`,
+      );
+    }
+    const finishError = finishResult.data.finishCreateOrUpdateFile.error;
+    if (finishError) {
+      throw new Error(
+        `${finishError.code}: ${finishError.message} (requestId ${finishError.requestId})`,
       );
     }
 
@@ -411,12 +452,13 @@ mutation CreateAnnouncement(
     body: $body
     attachments: $attachments
   ) {
-    isSuccess
     message
     error {
-      message
       code
+      message
+      requestId
       retryable
+      details
     }
   }
 }
@@ -439,7 +481,7 @@ curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Authorization: YOUR_CONSUMER_CREDENTIAL' \
   -H 'X-Service-Token: YOUR_SERVICE_TOKEN' \
   -d '{
-    "query": "mutation CreateAnnouncement($oclId: String!, $headline: String!, $body: String!, $attachments: [String!]) { createAnnouncement(oclId: $oclId, headline: $headline, body: $body, attachments: $attachments) { isSuccess message error { message } } }",
+    "query": "mutation CreateAnnouncement($oclId: String!, $headline: String!, $body: String!, $attachments: [String!]) { createAnnouncement(oclId: $oclId, headline: $headline, body: $body, attachments: $attachments) { message error { code message requestId retryable details } } }",
     "variables": {
       "oclId": "0x0101000000000000000000000000000000000000000000000000000000000042",
       "headline": "Research Milestone Achieved",
@@ -477,12 +519,13 @@ mutation UpdateFileMetadata(
     contentText: $contentText
   ) {
     ref
-    isSuccess
     message
     error {
-      message
       code
+      message
+      requestId
       retryable
+      details
     }
   }
 }
@@ -509,7 +552,7 @@ curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Authorization: YOUR_CONSUMER_CREDENTIAL' \
   -H 'X-Service-Token: YOUR_SERVICE_TOKEN' \
   -d '{
-    "query": "mutation UpdateFileMetadata($oclId: String!, $ref: String!, $accessLevel: String!, $description: String, $tags: [String!], $categories: [String!], $contentText: String) { updateFileMetadata(oclId: $oclId, ref: $ref, accessLevel: $accessLevel, description: $description, tags: $tags, categories: $categories, contentText: $contentText) { ref isSuccess message error { message } } }",
+    "query": "mutation UpdateFileMetadata($oclId: String!, $ref: String!, $accessLevel: String!, $description: String, $tags: [String!], $categories: [String!], $contentText: String) { updateFileMetadata(oclId: $oclId, ref: $ref, accessLevel: $accessLevel, description: $description, tags: $tags, categories: $categories, contentText: $contentText) { ref message error { code message requestId retryable details } } }",
     "variables": {
       "oclId": "0x0101000000000000000000000000000000000000000000000000000000000042",
       "ref": "did:kamu:fed01...",
@@ -535,11 +578,12 @@ mutation DeleteFile($oclId: String!, $path: String!, $changeBy: String!) {
   deleteDataRoomFile(oclId: $oclId, path: $path, changeBy: $changeBy) {
     oclId
     filePath
-    isSuccess
     error {
-      message
       code
+      message
+      requestId
       retryable
+      details
     }
   }
 }
@@ -563,7 +607,7 @@ curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Authorization: YOUR_CONSUMER_CREDENTIAL' \
   -H 'X-Service-Token: YOUR_SERVICE_TOKEN' \
   -d '{
-    "query": "mutation DeleteFile($oclId: String!, $path: String!, $changeBy: String!) { deleteDataRoomFile(oclId: $oclId, path: $path, changeBy: $changeBy) { oclId filePath isSuccess error { message } } }",
+    "query": "mutation DeleteFile($oclId: String!, $path: String!, $changeBy: String!) { deleteDataRoomFile(oclId: $oclId, path: $path, changeBy: $changeBy) { oclId filePath error { code message requestId retryable details } } }",
     "variables": {
       "oclId": "0x0101000000000000000000000000000000000000000000000000000000000042",
       "path": "old-data.pdf",
@@ -625,21 +669,15 @@ Return the valid file categories and their tags from the CMS. Use these when tag
 ```graphql
 query FileCategoriesAndTags {
   fileCategoriesAndTags {
-    isSuccess
     data {
       name
       tags
-    }
-    error {
-      message
-      code
-      retryable
     }
   }
 }
 ```
 
-Each entry in `data` is a `FileCategory` with a `name` and its list of allowed `tags`.
+Each entry in `data` is a `FileCategory` with a `name` and its list of allowed `tags`. Failures arrive as top-level GraphQL `errors[]` entries with `errorType` set to the catalogue code (e.g. `UPSTREAM_UNAVAILABLE`); the result type has no `error` field.
 
 ---
 
@@ -724,24 +762,26 @@ Generate a standalone data encryption key (DEK) for client-side encryption outsi
 ```graphql
 mutation GenerateDataEncryptionKey {
   generateDataEncryptionKey {
-    isSuccess
     plaintextDEK
     encryptedDek
     encryptionSystem
     error {
-      message
       code
+      message
+      requestId
       retryable
+      details
     }
   }
 }
 ```
 
-| Field            | Type   | Description                                                |
-| ---------------- | ------ | ---------------------------------------------------------- |
-| plaintextDEK     | String | Base64-encoded plaintext DEK (only present on success)     |
-| encryptedDek     | String | Base64-encoded KMS-encrypted DEK (only present on success) |
-| encryptionSystem | String | Encryption system used (always `"kms"`)                    |
+| Field            | Type     | Description                                                |
+| ---------------- | -------- | ---------------------------------------------------------- |
+| plaintextDEK     | String   | Base64-encoded plaintext DEK (only present on success)     |
+| encryptedDek     | String   | Base64-encoded KMS-encrypted DEK (only present on success) |
+| encryptionSystem | String   | Encryption system used (always `"kms"`)                    |
+| error            | ApiError | `null` on success; non-null means the mutation failed      |
 
 ---
 

--- a/api-reference/labs-api/lab-management.md
+++ b/api-reference/labs-api/lab-management.md
@@ -127,12 +127,13 @@ Register a Kamu-backed lab (data room) for an onchain lab (OCL) that already exi
 ```graphql
 mutation CreateLab($oclId: String!) {
   createLab(input: { oclId: $oclId }) {
-    isSuccess
     message
     error {
-      message
       code
+      message
+      requestId
       retryable
+      details
     }
     lab {
       oclId
@@ -187,7 +188,7 @@ curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Authorization: YOUR_CONSUMER_CREDENTIAL' \
   -H 'X-Service-Token: YOUR_SERVICE_TOKEN' \
   -d '{
-    "query": "mutation CreateLab($oclId: String!) { createLab(input: { oclId: $oclId }) { isSuccess message error { message code retryable } lab { oclId shortname labAccountAddress labNftTokenId } } }",
+    "query": "mutation CreateLab($oclId: String!) { createLab(input: { oclId: $oclId }) { message error { code message requestId retryable details } lab { oclId shortname labAccountAddress labNftTokenId } } }",
     "variables": {
       "oclId": "0x0101000000000000000000000000000000000000000000000000000000000042"
     }
@@ -200,7 +201,6 @@ curl -X POST https://production.graphql.api.molecule.xyz/graphql \
 {
   "data": {
     "createLab": {
-      "isSuccess": true,
       "message": "Lab created successfully",
       "error": null,
       "lab": {
@@ -216,31 +216,41 @@ curl -X POST https://production.graphql.api.molecule.xyz/graphql \
 
 **Error Responses:**
 
-**Not Authorized (No Token):**
+`createLab` reports failures in-band: `error` is `null` on success and a full `ApiError` on failure. Branch on `error.code` (and, where documented, the `reason` key inside `error.details`, a JSON-encoded string) — never on message text. The top-level `message` mirrors `error.message` on failure.
 
-```json
-{
-  "errors": [
-    {
-      "message": "Admin authorization required. Please contact Molecule team for service token access.",
-      "extensions": { "code": "UNAUTHORIZED" }
-    }
-  ]
-}
-```
-
-**Not the LabNFT Owner:**
+**Not Authenticated (No Token):**
 
 ```json
 {
   "data": {
     "createLab": {
-      "isSuccess": false,
-      "message": "User is not authorized for this lab",
+      "message": "Authentication required. Please provide either a service token (x-service-token header) or Privy authentication token (Authorization header + x-wallet-address header). Contact Molecule tech team to obtain a service token.",
       "error": {
-        "message": "Onchain verification failed: wallet address is not owner or authorized signer",
-        "code": "OWNERSHIP_VERIFICATION_FAILED",
-        "retryable": false
+        "code": "UNAUTHENTICATED",
+        "message": "Authentication required. Please provide either a service token (x-service-token header) or Privy authentication token (Authorization header + x-wallet-address header). Contact Molecule tech team to obtain a service token.",
+        "requestId": "8f1e4c9a-2b7d-4e10-9c3a-5d6f7a8b9c0d",
+        "retryable": false,
+        "details": "{\"reason\":\"NO_AUTH\"}"
+      },
+      "lab": null
+    }
+  }
+}
+```
+
+**Not the LabNFT Owner (Privy user token):**
+
+```json
+{
+  "data": {
+    "createLab": {
+      "message": "You are not allowed to perform this operation.",
+      "error": {
+        "code": "UNAUTHORIZED",
+        "message": "You are not allowed to perform this operation.",
+        "requestId": "2b9c11d0-6f3e-4a71-8d52-c4e9b0a1f7d3",
+        "retryable": false,
+        "details": "{\"reason\":\"UNAUTHORIZED\"}"
       },
       "lab": null
     }
@@ -254,12 +264,13 @@ curl -X POST https://production.graphql.api.molecule.xyz/graphql \
 {
   "data": {
     "createLab": {
-      "isSuccess": false,
-      "message": "Lab already exists for this oclId",
+      "message": "Project already exists",
       "error": {
-        "message": "A lab with this oclId already exists",
         "code": "CONFLICT",
-        "retryable": false
+        "message": "Project already exists",
+        "requestId": "5c7d2e81-9a4b-4f06-b3e8-1d0f6a2c8e94",
+        "retryable": false,
+        "details": "{\"reason\":\"PROJECT_CONFLICT\"}"
       },
       "lab": null
     }
@@ -366,13 +377,14 @@ mutation UpdateLabNftMetadata(
   $input: UpdateLabNftMetadataInput!
 ) {
   updateLabNftMetadata(oclId: $oclId, input: $input) {
-    isSuccess
     oclId
     message
     error {
-      message
       code
+      message
+      requestId
       retryable
+      details
     }
   }
 }
@@ -399,11 +411,12 @@ mutation GenerateLabImageUploadUrl($oclId: String!, $contentType: String!) {
     uploadUrl
     key
     expiresAt
-    isSuccess
     error {
-      message
       code
+      message
+      requestId
       retryable
+      details
     }
   }
 }
@@ -431,7 +444,6 @@ Return the active members of a lab (owner, contributors, viewers), sourced from 
 ```graphql
 query ListLabMembers($oclId: String!) {
   listLabMembers(oclId: $oclId) {
-    isSuccess
     message
     members {
       walletAddress
@@ -441,14 +453,11 @@ query ListLabMembers($oclId: String!) {
       isAgent
       grantedAt
     }
-    error {
-      message
-      code
-      retryable
-    }
   }
 }
 ```
+
+Failures throw: they arrive as top-level GraphQL `errors[]` entries with `errorType` set to the catalogue code (an unknown `oclId` throws `NOT_FOUND`). The response carries `"data": null` (the field is non-nullable, so the error propagates to the root) and `errors[0].path` names `listLabMembers`.
 
 **Parameters:**
 
@@ -480,7 +489,6 @@ Public read-only snapshot of DID-linking state for an OCL. DID-linking runs auto
 ```graphql
 query GetDidLinkStatus($oclId: String!) {
   getDidLinkStatus(oclId: $oclId) {
-    isSuccess
     message
     didLinkStatus {
       oclId
@@ -493,14 +501,11 @@ query GetDidLinkStatus($oclId: String!) {
       attempts
       updatedAt
     }
-    error {
-      message
-      code
-      retryable
-    }
   }
 }
 ```
+
+Failures throw: they arrive as top-level GraphQL `errors[]` entries with `errorType` set to the catalogue code. The response carries `"data": null` (the field is non-nullable, so the error propagates to the root) and `errors[0].path` names `getDidLinkStatus`.
 
 **Parameters:**
 

--- a/api-reference/labs-api/legal-agreements.md
+++ b/api-reference/labs-api/legal-agreements.md
@@ -30,7 +30,7 @@ LegalAgreementAcceptance(
 )
 ```
 
-> **`agreementType` is the registry slug, not the `LegalAgreementType` enum value.** The GraphQL enum (`type: LegalAgreementType`) uses `ASSIGNMENT_AGREEMENT`; the signed `agreementType` field uses the human-readable slug the wallet renders to the user. Signing with the enum value instead of the slug produces a digest the backend can't match — `signLegalAgreement` fails with `INVALID_SIGNATURE`.
+> **`agreementType` is the registry slug, not the `LegalAgreementType` enum value.** The GraphQL enum (`type: LegalAgreementType`) uses `ASSIGNMENT_AGREEMENT`; the signed `agreementType` field uses the human-readable slug the wallet renders to the user. Signing with the enum value instead of the slug produces a digest the backend can't match — `signLegalAgreement` returns `error.code` `UNAUTHENTICATED` with `details.reason` `INVALID_SIGNATURE`.
 
 | `LegalAgreementType` (GraphQL enum) | `agreementType` (signed slug) |
 | ------------------------------------ | ------------------------------- |
@@ -137,20 +137,16 @@ query LegalAgreementTemplate(
     entity: $entity
     title: $title
   ) {
-    isSuccess
     agreement
     contentHash
     templateVersion
     agreementType
     issuedAt
-    error {
-      message
-      code
-      retryable
-    }
   }
 }
 ```
+
+This is a query: failures arrive as top-level GraphQL `errors[]` entries with `errorType` set to a catalogue code (e.g. `UNAUTHENTICATED`, `UNAUTHORIZED`, `NOT_FOUND`, `VALIDATION_FAILED`), and `data` comes back `null` (the field is non-nullable, so the error propagates to the root). The result type has no `error` field.
 
 **Parameters:**
 
@@ -172,7 +168,6 @@ Whether (and at which template versions) the agreement has been signed for the l
 ```graphql
 query LegalAgreementStatus($oclId: String!, $type: LegalAgreementType!) {
   legalAgreementStatus(oclId: $oclId, type: $type) {
-    isSuccess
     signed
     isCurrentVersionSigned
     currentTemplateVersion
@@ -185,16 +180,34 @@ query LegalAgreementStatus($oclId: String!, $type: LegalAgreementType!) {
       issuedAt
       signature
     }
-    error {
-      message
-      code
-      retryable
+  }
+}
+```
+
+> **Two surfaces, two failure modes.** As the top-level `legalAgreementStatus(oclId, type)` query above, failures throw like every other query — a top-level GraphQL `errors[]` entry with `errorType` set to a catalogue code — and the payload's `error` field is always `null`. As the `Lab.legalAgreementStatus` / `LabRef.legalAgreementStatus` field, an upstream failure does not null the whole lab: the field returns the payload with `error` set (typically `UPSTREAM_UNAVAILABLE`). There, `error != null` means the status could not be determined and `signed` / `isCurrentVersionSigned` must not be trusted; only when `error == null` does `signed: false` mean "not signed". Select `error { code message requestId retryable details }` on that field and check it before routing a signing flow — for example, inline on `labs`:
+
+```graphql
+query LabsWithAgreementStatus {
+  labs(perPage: 5) {
+    nodes {
+      oclId
+      legalAgreementStatus(type: ASSIGNMENT_AGREEMENT) {
+        signed
+        isCurrentVersionSigned
+        error {
+          code
+          message
+          requestId
+          retryable
+          details
+        }
+      }
     }
   }
 }
 ```
 
-Check `isSuccess` before reading the other fields. `signed` is true if any version has been signed; `isCurrentVersionSigned` reflects the current template version (the FE routes the signing flow on this). The `signedVersions` enrichment is fetched lazily, only when its sub-fields are selected.
+`signed` is true if any version has been signed; `isCurrentVersionSigned` reflects the current template version (the FE routes the signing flow on this). The `signedVersions` enrichment is fetched lazily, only when its sub-fields are selected.
 
 ## Sign Legal Agreement (mutation)
 
@@ -203,7 +216,6 @@ Record acceptance of a legal agreement. The backend regenerates the document fro
 ```graphql
 mutation SignLegalAgreement($input: SignLegalAgreementInput!) {
   signLegalAgreement(input: $input) {
-    isSuccess
     oclId
     path
     contentHash
@@ -212,13 +224,17 @@ mutation SignLegalAgreement($input: SignLegalAgreementInput!) {
     version
     message
     error {
-      message
       code
+      message
+      requestId
       retryable
+      details
     }
   }
 }
 ```
+
+Success ⇔ `error == null`. On failure `message` mirrors `error.message`; branch on `error.code` (and `details.reason` where documented — e.g. `CONFLICT` with reason `ALREADY_SIGNED` when the current template version is already signed, or `FAILED_PRECONDITION` with reason `TEMPLATE_EXPIRED`). `details` is a JSON-encoded string: `JSON.parse(error.details ?? "{}").reason`.
 
 **`SignLegalAgreementInput` fields:**
 

--- a/api-reference/labs-api/service-tokens.md
+++ b/api-reference/labs-api/service-tokens.md
@@ -48,8 +48,14 @@ mutation GenerateServiceToken(
     serviceName
     expiresAt
     createdAt
-    isSuccess
     message
+    error {
+      code
+      message
+      requestId
+      retryable
+      details
+    }
   }
 }
 ```
@@ -63,6 +69,8 @@ mutation GenerateServiceToken(
 
 \* `walletAddress` and `messageSignature` must be provided together for signature-based issuance. The returned `token` is the JWT to pass as `X-Service-Token` on subsequent requests.
 
+Success ⇔ `error == null`. On failure `error` carries the catalogue `code` (e.g. `UNAUTHENTICATED` when the signature does not verify), `message` mirrors `error.message`, and `token`, `tokenId`, `expiresAt` and `createdAt` are `null` (`serviceName` may echo the name you sent) — guard for `null`, not for empty strings, and branch on `error`, never on the token fields.
+
 ## Extending Token Expiration
 
 You can extend your service token's expiration using the `extendServiceToken` mutation:
@@ -73,8 +81,14 @@ mutation ExtendServiceToken($tokenId: String!, $expiresIn: String!) {
     token
     tokenId
     expiresAt
-    isSuccess
     message
+    error {
+      code
+      message
+      requestId
+      retryable
+      details
+    }
   }
 }
 ```
@@ -93,7 +107,7 @@ curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Content-Type: application/json' \
   -H 'X-Service-Token: YOUR_CURRENT_TOKEN' \
   -d '{
-    "query": "mutation ExtendServiceToken($tokenId: String!, $expiresIn: String!) { extendServiceToken(tokenId: $tokenId, expiresIn: $expiresIn) { token tokenId expiresAt isSuccess message } }",
+    "query": "mutation ExtendServiceToken($tokenId: String!, $expiresIn: String!) { extendServiceToken(tokenId: $tokenId, expiresIn: $expiresIn) { token tokenId expiresAt message error { code message requestId retryable details } } }",
     "variables": {
       "tokenId": "your-token-id",
       "expiresIn": "90d"
@@ -101,7 +115,7 @@ curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   }'
 ```
 
-**Important:** Extension returns a **new JWT token** - update your stored token accordingly.
+**Important:** Extension returns a **new JWT token** - update your stored token accordingly. On failure `error` is set and `token` and `expiresAt` are `null`; `tokenId` may echo the id you sent, so branch on `error`, not on the token fields.
 
 ## Revoking Tokens
 
@@ -111,12 +125,20 @@ Revoke a service token immediately (e.g., if compromised):
 mutation RevokeServiceToken($tokenId: String!) {
   revokeServiceToken(tokenId: $tokenId) {
     tokenId
-    isSuccess
     message
     revokedAt
+    error {
+      code
+      message
+      requestId
+      retryable
+      details
+    }
   }
 }
 ```
+
+Success ⇔ `error == null`. On failure `message` mirrors `error.message`; do not infer the outcome from `tokenId` or `revokedAt` — `tokenId` may echo the id you sent, and when the token was already revoked (`CONFLICT`, reason `ALREADY_REVOKED`) `revokedAt` carries the original revocation time.
 
 **Example:**
 
@@ -125,7 +147,7 @@ curl -X POST https://production.graphql.api.molecule.xyz/graphql \
   -H 'Content-Type: application/json' \
   -H 'X-Service-Token: YOUR_CURRENT_TOKEN' \
   -d '{
-    "query": "mutation RevokeServiceToken($tokenId: String!) { revokeServiceToken(tokenId: $tokenId) { tokenId isSuccess message revokedAt } }",
+    "query": "mutation RevokeServiceToken($tokenId: String!) { revokeServiceToken(tokenId: $tokenId) { tokenId message revokedAt error { code message requestId retryable details } } }",
     "variables": {
       "tokenId": "your-token-id"
     }

--- a/api-reference/x402-gateway.md
+++ b/api-reference/x402-gateway.md
@@ -107,7 +107,7 @@ content-type: application/json
 payment-signature: <base64 x402 payment payload>
 
 {
-  "query": "mutation CreateAnnouncement($oclId: String!, $headline: String!, $body: String!) { createAnnouncement(oclId: $oclId, headline: $headline, body: $body) { isSuccess message error { message } } }",
+  "query": "mutation CreateAnnouncement($oclId: String!, $headline: String!, $body: String!) { createAnnouncement(oclId: $oclId, headline: $headline, body: $body) { message error { code message requestId retryable details } } }",
   "variables": {
     "oclId": "0x0101...abcd",
     "headline": "Milestone 1 complete",
@@ -116,6 +116,8 @@ payment-signature: <base64 x402 payment payload>
   "operationName": "CreateAnnouncement"
 }
 ```
+
+The `200` body is the mutation's GraphQL response verbatim, so read it exactly as on the Labs API: the mutation succeeded when `error` is `null`; otherwise branch on `error.code` — see [Error Handling](labs-api/README.md#error-handling). Note that settlement is triggered by the upstream `2xx`, not by mutation success — a `200` whose body carries a non-null `error` (e.g. `VALIDATION_FAILED`, `UNAUTHORIZED`) is still settled, so you pay for a mutation that failed in-band; only an upstream `4xx`/`5xx` skips settlement. Validate inputs (ids, categories/tags, role) before paying.
 
 Constraints enforced by the gateway (`validateMutationQuery`):
 

--- a/technical-deep-dive/data/data-privacy-and-access.md
+++ b/technical-deep-dive/data/data-privacy-and-access.md
@@ -203,11 +203,10 @@ mutation {
     oclId: "0x0101000000000000000000000000000000000000000000000000000000000042"
     filePath: "raw/experiment-01.csv"   # OR tokenUri + agreementUrl for IPFS agreements
   ) {
-    isSuccess
     plaintextDEK   # base64, client-only, wipe after use
     iv             # base64 AES-GCM IV from stored metadata
-    message
-    error { message code retryable }
+    message        # mirrors error.message on failure
+    error { code message requestId retryable details }   # null on success
   }
 }
 ```
@@ -222,7 +221,7 @@ AI agents encrypt and decrypt lab files through the same GraphQL interface, usin
 * **Role grant** — The Lab owner grants the agent's wallet a Contributor (or Viewer) role via `AccessResolver.grantRole` with `isAgent = true` and a bounded `expiry`. The `isAgent` flag is surfaced in the team-members UI so agent session keys are clearly distinguished from human collaborators.
 * **Encrypt** — The agent calls `generateDataEncryptionKey`, receives a plaintext DEK, encrypts the file locally (Node.js `crypto` / Web Crypto), uploads the ciphertext via `initiateCreateOrUpdateFile` → PUT, then calls `finishCreateOrUpdateFile` with the encryption metadata.
 * **Decrypt** — The agent calls `decryptDataKey(oclId, filePath)`. The backend evaluates the stored conditions against live chain state; a valid Viewer/Contributor grant satisfies the `hasRole` predicate. The backend returns the plaintext DEK over TLS; the agent decrypts locally.
-* **Expiry** — When the role grant expires (`block.timestamp >= expiry`), `hasRole` returns `false` and `decryptDataKey` starts failing with a conditions-not-met error. The agent must request a fresh grant — typically from an owner-controlled orchestrator — before it can continue.
+* **Expiry** — When the role grant expires (`block.timestamp >= expiry`), `hasRole` returns `false` and `decryptDataKey` stops returning a key: the result comes back with `plaintextDEK: null` and a non-null in-band `error` (typically `code` `UNAUTHORIZED` — the wallet no longer holds a qualifying role) instead; branch on `error.code` as described in the Labs API [Error Handling](../../api-reference/labs-api/README.md#error-handling) section. The agent must request a fresh grant — typically from an owner-controlled orchestrator — before it can continue.
 
 See the [Developers / AI Agents guide](../../user-guides/developers-ai-agents.md) for end-to-end agent integration patterns and the [MCP Tools reference](../../references/mcp-tools.md) for the read-side agent toolset.
 


### PR DESCRIPTION
## What this does

Updates the Labs API reference pages so every example matches what the API returns today. The `isSuccess` field was removed from the Labs API in desci-infra 1.0.14 (released 2026-08-04); a request that still asks for it is rejected before it runs (`Field 'isSuccess' in type '…Result' is undefined`). Eight public pages still taught it — 40 places in total.

## Why

Since 2026-08-04, anyone copying our examples gets a validation error instead of a response. The "Error Handling" section also described an HTTP-status error table that this GraphQL API never produced.

## What changes for you

- **Mutations** (`createLab`, the file-upload steps, `createAnnouncement`, `updateFileMetadata`, `deleteDataRoomFile`, `generateDataEncryptionKey`, `decryptDataKey`, the service-token mutations, `signLegalAgreement`): examples now select `error { code message requestId retryable details }`; success means `error` is `null`. JSON response examples are updated to match, using the real error codes.
- **Queries** (`activities`, `fileCategoriesAndTags`, `listLabMembers`, `getDidLinkStatus`, `legalAgreementTemplate`, `legalAgreementStatus`): `isSuccess` and `error` are removed from the selection; each page now says failures arrive as top-level GraphQL `errors[]` with `errorType`.
- **Labs API › Error Handling** is rewritten: the two channels (queries throw, mutations return `error`), the `ApiError` shape, the error-code table with `retryable`, and troubleshooting keyed to codes.
- **Service tokens**: token fields are `null` on failure (previously empty strings).
- **Legal agreements**: explains the two behaviours of `legalAgreementStatus` (top-level query vs. field on a lab).
- **x402 gateway**: same selection set for the proxied mutation, plus a note that a mutation that fails in-band is still settled.

Pages: `api-reference/labs-api/{README,files,lab-management,legal-agreements,service-tokens,browse-and-search}.md`, `api-reference/x402-gateway.md`, `technical-deep-dive/data/data-privacy-and-access.md`.

## How it was checked

Every GraphQL operation embedded in these pages (fenced blocks, curl JSON strings, JS template literals) was validated against desci-infra's current `graphql/schemas/merged-schema.graphql`: 46 invalid → 0. The one block still failing (`onChainActivity` in browse-and-search.md, unrelated field names) is pre-existing and left for a separate fix.

## Related

- The Tokenization API pages are untouched on purpose: that surface still returns `isSuccess`.
- Overlaps with #20 (IP-2936) in files.md, lab-management.md, service-tokens.md and data-privacy-and-access.md — whichever merges second needs a small rebase.
- Companion PRs: example workflow (PR_B) and changelog / release notes (PR_C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgBi7gZnVmFyeeihsMyhbN
