### PR TITLE
docs(changelog): announce the Labs API error-contract change — isSuccess removed (IP-2922)

### DIFF
--- a/api-reference/changelog.md
+++ b/api-reference/changelog.md
@@ -31,6 +31,99 @@ The production endpoint (shared by all Molecule APIs — see [API Overview](READ
 
 **Migration:** If your codegen or tooling discovers the schema by introspecting the production endpoint, that now fails — request a current copy of the schema from the Molecule team (see [Getting Support](README.md)) rather than introspecting production. If you see `QueryDepthLimitReached`, flatten the query to 10 levels of nesting or fewer; this limit was not previously enforced.
 
+### `isSuccess` removed (unified error contract)
+
+The Labs API now reports failure one way per operation class, and the `isSuccess` envelope is gone:
+
+- **Queries throw.** A failed query surfaces as an entry in the top-level GraphQL `errors[]` array; the failed field is `null`, and because most Labs query fields are non-null the null propagates and `data` itself comes back `null` (only `labWithDataRoomAndFiles` and `dataRoomFile` null just their own field). `errorType` carries the error code (table below) — the only value to branch on — and `errorInfo { requestId, retryable, details }` carries the correlation id and structured context. Query result types (`ActivitiesResult`, `FileCategoriesAndTagsResult`, `ListLabMembersResult`, `DidLinkStatusResult`, `LegalAgreementTemplateResult`, `ServiceSignInMessageResult`) no longer have an `isSuccess` or an `error` field.
+- **Mutations return errors in-band.** Every mutation `*Result` carries a nullable `error: ApiError`. **Success ⇔ `error == null`.** A top-level `errors[]` entry on a mutation means a transport or infrastructure failure (or an invalid request document), not a business outcome. Where a result keeps a top-level `message`, it mirrors `error.message` on failure and is never empty.
+
+`isSuccess` has been **removed** from every Labs result type, and the `error` field on mutation results is now typed `ApiError` (the previous error type no longer exists). A document that still selects `isSuccess` is rejected at validation (`Field 'isSuccess' in type '…Result' is undefined`) and never executes.
+
+Behaviour that changed alongside the envelope:
+
+- **Auth denials are code-accurate.** The former `AUTH_FAILED` catch-all is split into `UNAUTHENTICATED` (missing, invalid or expired credentials), `UNAUTHORIZED` (authenticated but lacking the role or membership), `NOT_FOUND` (the lab does not exist) and `VALIDATION_FAILED` (malformed input).
+- **Legacy codes live on as `details.reason`.** Codes such as `PROJECT_NOT_FOUND`, `LAB_NOT_FOUND`, `INVALID_OCL_ID` or `SHORTNAME_TAKEN` are no longer top-level codes; they survive as the `reason` key inside `details`, beneath the catalogue code (for example `CONFLICT` with `reason: "SHORTNAME_TAKEN"`). Branch on `code` first and on `reason` only where a page documents it.
+- **Service tokens.** `ServiceTokenResult` and `ServiceTokenRevocationResult` gained `error: ApiError`; `token`, `tokenId`, `serviceName`, `expiresAt`, `createdAt` and `revokedAt` are `null` on failure instead of `""`.
+- **`InitiateFileUploadResult.method`** is nullable and `null` on failure.
+- **`LegalAgreementStatusResult` is dual-surface.** As the `legalAgreementStatus(oclId, type)` query, failures throw and `error` is always `null`. As the `legalAgreementStatus` field on `Lab` / `LabRef`, an upstream failure returns the payload with `error` set (typically `UPSTREAM_UNAVAILABLE`) instead of nulling the lab: `error != null` means the status could not be determined, and only when `error == null` does `signed: false` mean "not signed".
+- `listLabMembers` on an unknown lab throws `NOT_FOUND` (previously a `PROJECT_NOT_FOUND` envelope). `createLab` conflicts return `CONFLICT` with `details.reason` `PROJECT_CONFLICT` (lab already registered) or `ACCOUNT_NAME_CONFLICT`.
+
+> **The Tokenization API is unaffected.** Its operations keep their previous result envelope (a success flag alongside an `error` object), exactly as documented in the [Tokenization API reference](tokenization-api.md). This section applies to the Labs API only.
+
+#### `ApiError`
+
+```graphql
+type ApiError {
+  code: String!       # error code from the table below — the only field to branch on
+  message: String!    # human-readable, never empty; not part of the contract
+  requestId: String!  # correlation id — include it in bug reports
+  retryable: Boolean! # whether an unchanged retry can plausibly succeed
+  details: AWSJSON    # optional structured context — keys: field, reason, hint, docs
+}
+```
+
+On an in-band mutation error, `details` arrives as a JSON-encoded string (AppSync `AWSJSON`), e.g. `"details": "{\"reason\":\"NOT_LAB_OWNER\"}"` — read it with `JSON.parse(error.details ?? "{}")`. On a thrown query error, `errorInfo.details` is a plain object. Ignore keys you do not recognise, and never match on `message` — its wording may change without notice.
+
+#### Error codes
+
+| Code                        | `retryable` | Meaning                                                                  | Typical `details.reason`                                                         |
+| --------------------------- | ----------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| `UNAUTHENTICATED`           | false       | Missing, invalid or expired credentials.                                 | `TOKEN_EXPIRED`, `INVALID_SIGNATURE`, `WALLET_MISMATCH`                          |
+| `UNAUTHORIZED`              | false       | Authenticated but not allowed (role or membership).                      | `NOT_LAB_OWNER`, `NOT_CONTRIBUTOR`, `SERVICE_NOT_WHITELISTED`                    |
+| `NOT_FOUND`                 | false       | The referenced resource does not exist.                                  | `LAB_NOT_FOUND`, `PROJECT_NOT_FOUND`, …                                          |
+| `VALIDATION_FAILED`         | false       | Input failed validation; `details.field` names the offending field.      | `INVALID_OCL_ID`, …                                                              |
+| `CONFLICT`                  | false       | A valid request conflicts with current state.                            | `SHORTNAME_TAKEN`, `ALREADY_SIGNED`, `PROJECT_CONFLICT`, `ACCOUNT_NAME_CONFLICT` |
+| `FAILED_PRECONDITION`       | false       | Resource state makes the operation impossible until that state changes.  | `TEMPLATE_EXPIRED`, `LEGACY_ENCRYPTION`, `NOT_ENCRYPTED`                         |
+| `COMPLEXITY_LIMIT_EXCEEDED` | false       | Query shape or result size is over the limit.                            | `FILTER_COMPLEXITY_LIMIT`, `RESULT_CARDINALITY_LIMIT`                            |
+| `RATE_LIMITED`              | **true**    | Throttled — retry with backoff.                                          | —                                                                                |
+| `TIMEOUT`                   | **true**    | Execution exceeded the request budget.                                   | —                                                                                |
+| `UPSTREAM_UNAVAILABLE`      | **true**    | A dependency failed — retry with backoff.                                | `KAMU`, `CMS`, `IPFS`                                                            |
+| `INTERNAL_ERROR`            | **true**    | Unexpected failure; quote `requestId` when reporting it.                 | —                                                                                |
+
+Codes may be added over time, and each addition is announced on this page. Treat a code you do not recognise as non-retryable, keep the raw value for diagnostics and surface it to a human. `PAYMENT_REQUIRED` is reserved for the x402 gateway and is not emitted by the GraphQL API. `details.reason` values are diagnostic refinement, not a contract surface — they may be extended without notice.
+
+#### Before / after
+
+```diff
+# Query selection (listLabMembers) — the envelope field is gone; failures
+# arrive as top-level errors[] with errorType
+  query ListLabMembers($oclId: String!) {
+    listLabMembers(oclId: $oclId) {
+-     isSuccess
+      message
+      members {
+        walletAddress
+        role
+      }
+    }
+  }
+```
+
+```diff
+# Mutation selection (createAnnouncement) — select `error` instead of `isSuccess`
+  mutation CreateAnnouncement($oclId: String!, $headline: String!, $body: String!) {
+    createAnnouncement(oclId: $oclId, headline: $headline, body: $body) {
+-     isSuccess
+      message
+-     error { message code retryable }
++     error { code message requestId retryable details }
+    }
+  }
+```
+
+```diff
+- if (!result.isSuccess) {
+-   handle(result.error?.code);
+- }
++ if (result.error) {
++   const { reason } = JSON.parse(result.error.details ?? "{}");
++   handle(result.error.code, reason);
++ }
+```
+
+**Migration:** Remove `isSuccess` (and, except on `legalAgreementStatus`, any `error { … }` selection) from every Labs query document — a document that still selects it fails validation and the query never runs — and handle failures from the top-level `errors[]` array, keyed on `errorType`. On mutations, replace `isSuccess` with `error { code message requestId retryable details }`, treat `error == null` as success, and branch on `error.code` (plus `details.reason` where documented), never on `message` text. Replace any check on the former `AUTH_FAILED` catch-all with the split codes listed above, and any `token === ""` / `tokenId === ""` checks on service-token results with `null` checks. If you read `legalAgreementStatus` off a lab object, select `error { code message }` and check it before trusting `signed`. Leave your Tokenization API handling as it is. See [Labs API › Error Handling](labs-api/README.md#error-handling) for the full reference.
+
 ### `*V2` operations and pre-OCL naming removed
 
 The legacy `*V2` operations and the pre-OCL naming have been **removed**. The current API is `oclId`-based. If you are migrating from an older integration, use the current names below.

--- a/release-notes/labs-api.md
+++ b/release-notes/labs-api.md
@@ -18,5 +18,17 @@ _Released 2026-08-18_
 
 The production endpoint no longer serves `__schema` / `__type` introspection queries — they return a validation error. `__typename` still resolves. Selection-set depth is also capped at 10 in production; a query beyond that fails at execution time with `errorType: "QueryDepthLimitReached"` rather than the usual error shape. See [API Changelog & Migration](../api-reference/changelog.md#graphql-introspection-disabled-and-query-depth-capped-in-production) for details and migration steps.
 
-For migrations off the pre-OCL naming and the `*V2` operations, see
-[API Changelog & Migration](../api-reference/changelog.md).
+## 1.0.14
+
+_Released 2026-08-04_
+
+### Breaking changes
+
+#### `isSuccess` removed (unified error contract)
+
+Every Labs API result type lost its `isSuccess` flag, and mutation results now carry a nullable `error: ApiError` instead of the previous error type; a document that still selects `isSuccess` fails GraphQL validation. Queries throw: a failed query surfaces as a top-level GraphQL `errors[]` entry whose `errorType` is a catalogue code such as `UNAUTHENTICATED` or `NOT_FOUND`. Mutations return errors in-band, and success means `error == null`. Authentication denials, legacy error codes, service-token result fields and `InitiateFileUploadResult.method` changed alongside the envelope. The Tokenization API is unaffected and keeps its previous result envelope.
+
+**Migration:** Drop `isSuccess` (and, except on `legalAgreementStatus`, any `error { … }` selection) from query documents and handle the top-level `errors[]` array keyed on `errorType`; on mutations select `error { code message requestId retryable details }` and branch on `error.code` instead of `message`. See [API Changelog & Migration](../api-reference/changelog.md#issuccess-removed-unified-error-contract) for the before/after examples, the `ApiError` shape, the full code table and the field-level changes.
+
+For migrations off the removed `isSuccess` envelope, the pre-OCL naming and the `*V2`
+operations, see [API Changelog & Migration](../api-reference/changelog.md).


### PR DESCRIPTION
## What this does

Adds the one breaking change that the public changelog and release notes never recorded: on 2026-08-04 (desci-infra 1.0.14) the Labs API dropped the `isSuccess` field from every result type and moved to a single error contract — queries throw top-level GraphQL errors, mutations return an `error` object (`null` on success).

## Why

Integrators who last read the docs before August have no public record of why their requests started failing validation, or of what to select instead.

## What changes for you

- `api-reference/changelog.md` gets a new Labs API section, "`isSuccess` removed (unified error contract)", placed in date order between the introspection change (2.0.1) and the pre-OCL rename. It covers what changed, the `ApiError` shape, the error-code table, before/after selections for a query and a mutation, and a migration paragraph. It says explicitly that the Tokenization API is unaffected.
- `release-notes/labs-api.md` gets a `1.0.14` entry (released 2026-08-04) in the existing format, linking to that section.

## Related

Companion PRs bring the pages themselves in line with this entry: reference pages (PR_A) and example workflow (PR_B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgBi7gZnVmFyeeihsMyhbN
